### PR TITLE
[#18] Support global install

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 coverage
 node_modules
+build

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ build/Release
 node_modules
 
 .jshint*
+build

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+coverage
+test
+.babelrc
+.eslintignore
+.gitignore
+circle.yml
+.jshint*

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+lib
 coverage
 test
 .babelrc

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,10 +1,11 @@
-#! /usr/bin/env ./node_modules/.bin/babel-node
+#! /usr/bin/env node
 
 
+import 'babel/polyfill';
 import nomnom from 'nomnom';
-import cloverfield from './lib/cloverfield';
-import findScaffolds from './lib/find-scaffolds';
-import buildCommand from './lib/commands/build';
+import cloverfield from './cloverfield';
+import findScaffolds from './find-scaffolds';
+import buildCommand from './commands/build';
 
 
 const parser = nomnom();

--- a/lib/find-scaffolds.js
+++ b/lib/find-scaffolds.js
@@ -1,7 +1,7 @@
 import npm from 'npm';
 
 
-const isScaffold = ({keywords = [], name}) =>
+const isScaffold = ({keywords = [], name = ''}) =>
   name.substr(0, 3) === 'cf-' ||
   keywords.indexOf('cloverfield-scaffold') !== -1 ||
   keywords.indexOf('cloverfield') !== -1 && keywords.indexOf('scaffold') !== -1;

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A next generation JavaScript project boilerplate",
   "main": "index.js",
   "bin": {
-    "cloverfield": "index.js",
-    "cf": "index.js"
+    "cloverfield": "build/cli.js",
+    "cf": "build/cli.js"
   },
   "scripts": {
     "lint": "eslint .",
@@ -17,7 +17,11 @@
     "validate-dev": "npm run lint && npm test | faucet",
     "audit": "nsp package",
     "precheck": "npm run validate",
-    "check": "npm run audit && npm outdated --depth 0"
+    "check": "npm run audit && npm outdated --depth 0",
+    "build": "npm run build:clean && npm run build:lib",
+    "build:clean": "rimraf build",
+    "build:lib": "babel lib --out-dir build",
+    "prepublish": "npm run build"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
Babel ignores anything that is under node_modules, so even adding `babel/runtime` to the CLI entry point does not help. It is possible to manually specify options for it though. So I used custom ignore option to ignore everything under `cloverfield/node_modules` but it still did not work properly in runtime, so I had to go with compilation step instead.

I've tested the fresh install with 
```
[nkbt@nkbt] ~ $ npm install /Users/nkbt/nkbt/cloverfield -g
 
> cloverfield@0.2.0 prepublish /Users/nkbt/nkbt/cloverfield
> npm run build

/
> cloverfield@0.2.0 build /Users/nkbt/nkbt/cloverfield
> npm run build:clean && npm run build:lib

\
> cloverfield@0.2.0 build:clean /Users/nkbt/nkbt/cloverfield
> rimraf build

-
> cloverfield@0.2.0 build:lib /Users/nkbt/nkbt/cloverfield
> babel lib --out-dir build

lib/cli.js -> build/cli.js
lib/cloverfield.js -> build/cloverfield.js
lib/commands/build.js -> build/commands/build.js
lib/find-scaffolds.js -> build/find-scaffolds.js
 
> fsevents@0.3.8 install /Users/nkbt/.nvm/v0.10.40/lib/node_modules/cloverfield/node_modules/babel/node_modules/chokidar/node_modules/fsevents
> node-gyp rebuild

  SOLINK_MODULE(target) Release/.node
  CXX(target) Release/obj.target/fse/fsevents.o
  SOLINK_MODULE(target) Release/fse.node
/Users/nkbt/.nvm/v0.10.40/bin/cf -> /Users/nkbt/.nvm/v0.10.40/lib/node_modules/cloverfield/build/cli.js
/Users/nkbt/.nvm/v0.10.40/bin/cloverfield -> /Users/nkbt/.nvm/v0.10.40/lib/node_modules/cloverfield/build/cli.js
cloverfield@0.2.0 /Users/nkbt/.nvm/v0.10.40/lib/node_modules/cloverfield
├── nomnom@1.8.1 (underscore@1.6.0, chalk@0.4.0)
├── npm@2.13.4
└── babel@5.8.21 (slash@1.0.0, path-exists@1.0.0, path-is-absolute@1.0.0, fs-readdir-recursive@0.1.2, convert-source-map@1.1.1, commander@2.8.1, source-map@0.4.4, output-file-sync@1.1.1, glob@5.0.14, lodash@3.10.1, chokidar@1.0.5, babel-core@5.8.22)
```

For some reason npm treats anything under global `node_modules` as dependency. including `npm-debug.log` which just comes as almost empty object (without name or keyword)

<img width="498" alt="20150811-222914" src="https://cloud.githubusercontent.com/assets/175264/9197553/75a70778-4078-11e5-9f30-1cb8856e778e.png">

I checked some other libraries. For example babel itself comes pre-compiled, so I believe it is the right way to do.