### PR TITLE
[#33] Search for packages locally 

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,7 +4,7 @@
 import 'babel/polyfill';
 import nomnom from 'nomnom';
 import cloverfield from './cloverfield';
-import findScaffolds from './find-scaffolds';
+import {findGlobal, findLocal} from './find-scaffolds';
 import buildCommand from './commands/build';
 
 
@@ -12,8 +12,10 @@ const parser = nomnom();
 
 
 Promise.all([
-  findScaffolds()
+  Promise.all([findLocal(), findGlobal()])
     .catch(console.error.bind(console))
+    // Prefer local packages over global
+    .then(([local, global]) => ({...global, ...local}))
     .then(buildCommand)
 ])
   .then(cloverfield(parser))

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,13 +6,14 @@ import nomnom from 'nomnom';
 import cloverfield from './cloverfield';
 import {findGlobal, findLocal} from './find-scaffolds';
 import buildCommand from './commands/build';
+import npm from 'npm';
 
 
 const parser = nomnom();
 
 
 Promise.all([
-  Promise.all([findLocal(), findGlobal()])
+  Promise.all([findLocal(npm)(), findGlobal(npm)()])
     .catch(console.error.bind(console))
     // Prefer local packages over global
     .then(([local, global]) => ({...global, ...local}))

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -1,3 +1,5 @@
+import path from 'path';
+
 export default scaffolds => {
   const command = 'build';
 
@@ -12,8 +14,12 @@ export default scaffolds => {
     }
   };
 
-  const callback = ({scaffold, ...opts}) =>
-    require(scaffolds[scaffold])(opts);
+  const callback = ({scaffold, ...opts}) => {
+    const packageJson = require(path.join(scaffolds[scaffold], 'package.json'));
+    const cli = require(path.join(scaffolds[scaffold], packageJson.main));
+
+    return cli(opts);
+  };
 
   const help = 'Build a new package from a Cloverfield scaffold';
 

--- a/lib/find-scaffolds.js
+++ b/lib/find-scaffolds.js
@@ -1,6 +1,3 @@
-import npm from 'npm';
-
-
 const isScaffold = ({keywords = [], name}) => name && (
   name.substr(0, 3) === 'cf-' ||
   keywords.indexOf('cloverfield-scaffold') !== -1 ||
@@ -24,7 +21,7 @@ const modulesReady = (resolve, reject) => (error, tree) => {
 };
 
 
-const loaded = (resolve, reject) => (error) => {
+const loaded = npm => (resolve, reject) => (error) => {
   if (error) {
     return reject(error);
   }
@@ -35,12 +32,12 @@ const loaded = (resolve, reject) => (error) => {
 
 
 // TODO: add caching
-const findScaffolds = global => () =>
+const findScaffolds = npm => global => () =>
   // Configure npm to search for dependencies globally or locally with minimal depth
-  new Promise((...args) => npm.load({global, silent: true, depth: 0}, loaded(...args)));
+  new Promise((...args) => npm.load({global, silent: true, depth: 0}, loaded(npm)(...args)));
 
 
-export const findLocal = findScaffolds(false);
+export const findLocal = npm => findScaffolds(npm)(false);
 
 
-export const findGlobal = findScaffolds(true);
+export const findGlobal = npm => findScaffolds(npm)(true);

--- a/lib/find-scaffolds.js
+++ b/lib/find-scaffolds.js
@@ -32,12 +32,12 @@ const loaded = npm => (resolve, reject) => (error) => {
 
 
 // TODO: add caching
-const findScaffolds = npm => global => () =>
+const findScaffolds = npm => options => () =>
   // Configure npm to search for dependencies globally or locally with minimal depth
-  new Promise((...args) => npm.load({global, silent: true, depth: 0}, loaded(npm)(...args)));
+  new Promise((...args) => npm.load({silent: true, depth: 0, ...options}, loaded(npm)(...args)));
 
 
-export const findLocal = npm => findScaffolds(npm)(false);
+export const findLocal = npm => findScaffolds(npm)({global: false});
 
 
-export const findGlobal = npm => findScaffolds(npm)(true);
+export const findGlobal = npm => findScaffolds(npm)({global: true});

--- a/lib/find-scaffolds.js
+++ b/lib/find-scaffolds.js
@@ -1,10 +1,11 @@
 import npm from 'npm';
 
 
-const isScaffold = ({keywords = [], name = ''}) =>
+const isScaffold = ({keywords = [], name}) => name && (
   name.substr(0, 3) === 'cf-' ||
   keywords.indexOf('cloverfield-scaffold') !== -1 ||
-  keywords.indexOf('cloverfield') !== -1 && keywords.indexOf('scaffold') !== -1;
+  keywords.indexOf('cloverfield') !== -1 && keywords.indexOf('scaffold') !== -1
+);
 
 
 const modulesReady = (resolve, reject) => (error, tree) => {
@@ -34,9 +35,12 @@ const loaded = (resolve, reject) => (error) => {
 
 
 // TODO: add caching
-const findScaffolds = () =>
-  // Configure npm to search for dependencies globally with minimal depth
-  new Promise((...args) => npm.load({global: true, silent: true, depth: 0}, loaded(...args)));
+const findScaffolds = global => () =>
+  // Configure npm to search for dependencies globally or locally with minimal depth
+  new Promise((...args) => npm.load({global, silent: true, depth: 0}, loaded(...args)));
 
 
-export default findScaffolds;
+export const findLocal = findScaffolds(false);
+
+
+export const findGlobal = findScaffolds(true);


### PR DESCRIPTION
1. Added ability to search for global and local packages
2. Updated tests
3. Fixed issue with incorrect packages (without name), thanks to additional test
4. Updated cli to merge local and global packages
5. Fixed build command to require correct package CLI

Tested by installing fixed (corrected `main`) cf-package from fs: `npm install ~/nkbt/cf-package`. All picked up:

<img width="643" alt="20150825-232649" src="https://cloud.githubusercontent.com/assets/175264/9467690/d39ea53a-4b80-11e5-9995-cc27d817b80d.png">
